### PR TITLE
Fix: Regex error

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -262,7 +262,7 @@ class Helper:
 
         to_delete= []
         for i, line in enumerate(lines):
-            m = re.search(f'(\\externaldocument\\[)(.+?)(\\-\\]\\{{){filename}(\\}})', line)
+            m = re.search(rf'(\\externaldocument\[)(.+?)(\-\]\{{){filename}(\}})', line)
             if m:
                 to_delete.append(i)
 


### PR DESCRIPTION
This is a fix for a regex error which I get when trying to remove note using 
python manage.py remove_note note_name 

```
re.error: bad escape \e at position 1
```